### PR TITLE
Add README with viewing and Knack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Latino Family Connections Static Site
+
+This repository contains the exported static assets for the **Latino Family Connections** website. The files were generated using Webflow and can be viewed locally or hosted on any static web server.
+
+## Viewing the Site
+
+1. Clone or download this repository.
+2. Open `index.html` in your web browser, **or** run a simple HTTP server and navigate to `http://localhost:8000`:
+   ```bash
+   python3 -m http.server
+   ```
+
+## Future Knack Integration
+
+The site currently has no database-backed features. We plan to connect it to a [Knack](https://www.knack.com/) application in order to manage dynamic content. Integration steps will include:
+
+- Creating a Knack application with the required objects and fields.
+- Using the Knack API to fetch and display data within the existing HTML.
+- Adding JavaScript to authenticate and interact with Knack endpoints.
+
+Placeholders or additional scripts will be added here as the integration is implemented.
+


### PR DESCRIPTION
## Summary
- document how to view the static site
- outline future plans for Knack database integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435026a41c8328950fc52139eebbd4